### PR TITLE
Support py 2dot7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "2.7"
 install:
   - python setup.py install
   - pip install coveralls pytest-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "3.6"
+  - "3.5"
+  - "3.4"
+  - "3.3"
   - "2.7"
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 install:
   - python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ asciigraf
 .. image:: https://badge.fury.io/py/asciigraf.svg
     :target: https://pypi.python.org/pypi/asciigraf
 
+.. image:: https://img.shields.io/pypi/pyversions/asciigraf.svg
+    :target: https://pypi.python.org/pypi/asciigraf
+
 Asciigraf is a python library that turns ascii diagrams of networks into
 network objects. It returns a `networkx <https://networkx.github.io/>`__
 graph of nodes for each alpha-numeric element in the input text; nodes

--- a/asciigraf/__init__.py
+++ b/asciigraf/__init__.py
@@ -1,1 +1,1 @@
-from asciigraf.asciigraf import graph_from_ascii
+from .asciigraf import graph_from_ascii

--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -58,7 +58,7 @@ def graph_from_ascii(network_string):
         ]
         edge_char_to_edge_map[pos]["nodes"] += neighboring_nodes
 
-    ascii_graph = networkx.Graph()
+    ascii_graph = networkx.OrderedGraph()
     ascii_graph.add_nodes_from(nodes.keys())
     ascii_graph.add_edges_from(tuple(el["nodes"]) for el in edges)
     networkx.set_node_attributes(ascii_graph, name="position", values=nodes)

--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -15,7 +15,7 @@ def graph_from_ascii(network_string):
         "|":  [Point(-1, 0), Point(1, 0)]
     }
     EDGE_CHARS = {"\\", "-", "/", "|"}
-    nodes = {node_label: pos for node_label, pos in node_iter(network_string)}
+    nodes = OrderedDict(node_iter(network_string))
 
     node_chars = {}
     for node_label, pos in nodes.items():

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name="asciigraf",
-    version="0.1.3",
+    version="0.1.4",
     packages=["asciigraf"],
     description="A python library for making ascii-art into network graphs.",
     classifiers=[


### PR DESCRIPTION
Turns out we were getting lucky on the order of nodes in each edge and the order of nodes over all because of Python 3.6 implementation of dictionaries. Using OrderedDict and OrdereredGraph makes things much more compatible.

Also uses relative imports for 2.7 support.

Closes #14 